### PR TITLE
More descriptive name for perfetto-trace files

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ repository = "https://github.com/IrreducibleOSS/tracing-profile"
 
 [dependencies]
 cfg-if = "1.0.0"
+git2 = "0.20.1"
 ittapi = { version = "0.4.0", optional = true}
 linear-map = "1.2.0"
 nix = { version = "0.29", features = ["time"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,8 @@ repository = "https://github.com/IrreducibleOSS/tracing-profile"
 
 [dependencies]
 cfg-if = "1.0.0"
+chrono = "0.4.40"
+gethostname = "1.0.0"
 git2 = "0.20.1"
 ittapi = { version = "0.4.0", optional = true}
 linear-map = "1.2.0"

--- a/src/data/log_tree.rs
+++ b/src/data/log_tree.rs
@@ -44,11 +44,10 @@ impl LogTree {
 
             for event in &child.events {
                 if is_last {
-                    writeln!(f, "{}   ├>{}",prefix, event)?;
+                    writeln!(f, "{}   ├>{}", prefix, event)?;
                 } else {
-                    writeln!(f, "{}│  ├>{}",prefix, event)?;
+                    writeln!(f, "{}│  ├>{}", prefix, event)?;
                 }
-               
             }
 
             if !child.children.is_empty() {

--- a/src/layers/perfetto.rs
+++ b/src/layers/perfetto.rs
@@ -1,5 +1,6 @@
 // Copyright 2024 Irreducible Inc.
 
+use gethostname::gethostname;
 use perfetto_sys::{BackendConfig, EventData, PerfettoGuard};
 use tracing::{
     field::{Field, Visit},
@@ -97,16 +98,18 @@ impl Layer {
         let trace_file_patch = match std::env::var("PERFETTO_TRACE_FILE_PATH") {
             Ok(path) => path,
             Err(_) => {
-                let timestamp = get_unix_timestamp();
-                let branch = get_current_git_branch();
+                let time = get_formatted_time();
+                let branch = get_current_branch_revision();
                 let platform = std::env::var("PERFETTO_PLATFORM_NAME")
                     .unwrap_or(std::env::consts::ARCH.to_string());
+                let hostname = gethostname().into_string();
 
                 format!(
-                    "{}-{}{}.perfetto-trace",
-                    timestamp,
-                    platform,
-                    branch.map_or(String::new(), |b| format!("-{}", b))
+                    "{}{}{}{}.perfetto-trace",
+                    time,
+                    branch.map_or(String::new(), |b| format!("-{}", b)),
+                    format!("-{}", platform),
+                    hostname.map_or(String::new(), |h| format!("-{}", h)),
                 )
             }
         };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,6 +49,7 @@ mod data;
 mod env_utils;
 mod errors;
 mod layers;
+pub mod utils;
 
 #[cfg(feature = "ittapi")]
 pub use layers::ittapi::Layer as IttApiLayer;

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,28 +1,25 @@
+use chrono::Local;
 use git2::Repository;
-use std::time::{SystemTime, UNIX_EPOCH};
 
-pub fn get_unix_timestamp() -> u64 {
-    SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .expect("Time went backwards")
-        .as_secs()
+pub fn get_formatted_time() -> String {
+    Local::now().format("%Y_%m_%d_%H_%M").to_string()
 }
-
-pub fn get_current_git_branch() -> Option<String> {
+pub fn get_current_branch_revision() -> Option<String> {
     let repo = Repository::discover(".").ok()?;
     let head = repo.head().ok()?;
     let branch = head.shorthand()?;
-    Some(sanitize_filename(branch).to_string())
+    let commit = head.peel_to_commit().ok()?;
+    let short_hash = &commit.id().to_string()[..7];
+
+    Some(format!("{}_{}", sanitize_filename(branch), short_hash))
 }
 
-fn sanitize_filename(branch: &str) -> String {
+pub fn sanitize_filename(branch: &str) -> String {
     branch
         .chars()
-        .map(|c| {
-            match c {
-                '/' | '\\' | ':' | '*' | '?' | '"' | '<' | '>' | '|' | '#' | ' ' | '.' => '-',
-                _ => c,
-            }
+        .map(|c| match c {
+            '/' | '\\' | ':' | '*' | '?' | '"' | '<' | '>' | '|' | '#' | ' ' | '.' => '-',
+            _ => c,
         })
         .collect()
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,0 +1,28 @@
+use git2::Repository;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+pub fn get_unix_timestamp() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("Time went backwards")
+        .as_secs()
+}
+
+pub fn get_current_git_branch() -> Option<String> {
+    let repo = Repository::discover(".").ok()?;
+    let head = repo.head().ok()?;
+    let branch = head.shorthand()?;
+    Some(sanitize_filename(branch).to_string())
+}
+
+fn sanitize_filename(branch: &str) -> String {
+    branch
+        .chars()
+        .map(|c| {
+            match c {
+                '/' | '\\' | ':' | '*' | '?' | '"' | '<' | '>' | '|' | '#' | ' ' | '.' => '-',
+                _ => c,
+            }
+        })
+        .collect()
+}


### PR DESCRIPTION
It allows us to have more information about the Perfetto trace.
- timestamp
- platform 
- branch

example: `2025_03_21_13_44-adziadziuk-deduplication-evalcheck-ring-switch_e092463-x86_64-djadjka-cachyos.perfetto-trace`