### PR TITLE
Remove openssl reference from git2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ repository = "https://github.com/IrreducibleOSS/tracing-profile"
 cfg-if = "1.0.0"
 chrono = "0.4.40"
 gethostname = "1.0.0"
-git2 = "0.20.1"
+git2 = { version = "0.20.1", default-features = false }
 ittapi = { version = "0.4.0", optional = true}
 linear-map = "1.2.0"
 nix = { version = "0.29", features = ["time"] }


### PR DESCRIPTION
By default the system version is used during the build which may cause linker errors. Another option would be to use vendor one, but for our functionality openssl isn't necessary, so just disable.