### PR TITLE
Add metadata to the init tracing function

### DIFF
--- a/src/layers/init_tracing.rs
+++ b/src/layers/init_tracing.rs
@@ -50,6 +50,12 @@ pub enum Error {
 ///
 /// Returns the guard that should be kept alive for the duration of the program.
 pub fn init_tracing() -> Result<impl Drop, Error> {
+    init_tracing_with_metadata(&[])
+}
+
+pub fn init_tracing_with_metadata(
+    _metadata: &[(&'static str, String)],
+) -> Result<impl Drop, Error> {
     // Create print tree layer
     let (layer, guard) = PrintTreeLayer::new(PrintTreeConfig::default());
     let layer = tracing_subscriber::registry().with(layer.with_env_filter());
@@ -59,7 +65,7 @@ pub fn init_tracing() -> Result<impl Drop, Error> {
         cfg_if! {
             if #[cfg(feature = "perfetto")] {
                 let (new_layer, new_guard) =
-                    crate::PerfettoLayer::new_from_env()?;
+                    crate::PerfettoLayer::new_from_env(_metadata)?;
                 (layer.with(new_layer.with_env_filter()), crate::data::GuardWrapper::wrap(guard, new_guard))
             } else {
                 (layer, guard)

--- a/src/layers/perfetto.rs
+++ b/src/layers/perfetto.rs
@@ -97,7 +97,9 @@ impl Layer {
     /// - `PERFETTO_CFG_PATH`: path to the perfetto config file. If not set, the default one `config/system_profiling.cfg` will be used. Is used only with the system backend.
     /// - `PERFETTO_BUFFER_SIZE_KB`: size of the buffer in kilobytes. Default: 50 * 1024. Is used only with the in-process backend.
     /// - `PERFETTO_PLATFORM_NAME`: custom platform name. Default: architecture of the CPU that is currently in use.
-    pub fn new_from_env() -> Result<(Self, PerfettoGuard), perfetto_sys::Error> {
+    pub fn new_from_env(
+        metadata: &[(&'static str, String)],
+    ) -> Result<(Self, PerfettoGuard), perfetto_sys::Error> {
         let (timestamp_filename, timestamp_iso) = get_formatted_time();
         let git_info = get_git_info();
 
@@ -126,7 +128,7 @@ impl Layer {
         // Start tracing
         let guard = PerfettoGuard::new(backend, &output_path_str)?;
 
-        emit_run_metadata(output_path, timestamp_iso, git_info.as_ref());
+        emit_run_metadata(output_path, timestamp_iso, git_info.as_ref(), metadata);
 
         Ok((Self {}, guard))
     }

--- a/src/layers/perfetto_utils.rs
+++ b/src/layers/perfetto_utils.rs
@@ -45,6 +45,7 @@ pub(crate) fn emit_run_metadata(
     output_path: PathBuf,
     timestamp_iso: String,
     git_info: Option<&GitInfo>,
+    metadata: &[(&'static str, String)],
 ) {
     // Emit metadata
     let mut event_data = EventData::new("metadata:run_info");
@@ -80,6 +81,11 @@ pub(crate) fn emit_run_metadata(
     event_data.add_string_arg("arch", std::env::consts::ARCH);
     if let Ok(host) = gethostname().into_string() {
         event_data.add_string_arg("hostname", &host);
+    }
+
+    // Extra metadata from the metadata argument
+    for (key, val) in metadata {
+        event_data.add_string_arg(key, val);
     }
 
     // Extra metadata from the environment

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,7 +76,10 @@ pub use perfetto_sys::PerfettoGuard;
 #[cfg(feature = "tracy")]
 pub use tracing_tracy::TracyLayer;
 
-pub use layers::init_tracing::init_tracing;
+pub use layers::init_tracing::{init_tracing, init_tracing_with_metadata};
+
+#[macro_use]
+mod macros;
 
 #[cfg(test)]
 mod tests {

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,0 +1,31 @@
+// Copyright 2024-2025 Irreducible Inc.
+
+/// A macro that mirrors `init_tracing_with_metadata(&[(&str, String)])`
+/// but lets callers write `str: "key" = "value"`, `u64: "key" = 42`, etc.
+/// Under the hood, it converts values to strings.
+#[macro_export]
+macro_rules! init_tracing_with_metadata {
+    // 1) No pairs → just call the function with an empty slice.
+    () => {
+        $crate::init_tracing_with_metadata(&[])
+    };
+
+    // 2) One or more `key = value` entries, comma‐separated.
+    //    We capture each `key` as an identifier and `value` as any expression.
+    (
+        $(
+            $key:ident = $val:expr
+        ),* $(,)?
+    ) => {
+        $crate::init_tracing_with_metadata(&[
+            $(
+                // Turn `key` into a string at compile‐time, and
+                // call `.to_string()` on every `value`.
+                (
+                    stringify!($key),
+                    $val.to_string(),
+                )
+            ),*
+        ])
+    };
+}


### PR DESCRIPTION
Example usage:
```rust
	let _guard = tracing_profile::init_tracing_with_metadata!(
		benchmark = "keccak",
		n_permutations = n_permutations,
		log_inv_rate = args.log_inv_rate,
		benchmark_args = serde_json::json!({
			"n_permutations": n_permutations,
			"log_inv_rate":   args.log_inv_rate,
		})
		.to_string(),
	).expect("failed to initialize tracing");
```