### PR TITLE
emit max rss

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,9 +14,9 @@ cfg-if = "1.0.0"
 chrono = "0.4.40"
 gethostname = "1.0.0"
 git2 = { version = "0.20.1", default-features = false }
-ittapi = { version = "0.4.0", optional = true}
+ittapi = { version = "0.4.0", optional = true }
 linear-map = "1.2.0"
-nix = { version = "0.29", features = ["time"] }
+nix = { version = "0.29", features = ["time", "resource"] }
 perf-event = { version = "0.4.8", optional = true }
 perfetto-sys = { package = "tracing-profile-perfetto-sys", version = "0.10.1", path = "perfetto-sys", optional = true }
 thiserror = "2.0.3"

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -85,3 +85,34 @@ pub fn get_git_info() -> Option<GitInfo> {
         is_clean,
     })
 }
+
+/// Creates a [`tracing`] event with the resident set size at its peak in megabytes.
+///
+/// The name of the event is `max rss mib`.
+pub fn emit_max_rss() {
+    if let Some(max_rss) = get_max_rss() {
+        let max_rss_mb = if cfg!(target_os = "linux") {
+            // The maxrss is in kbytes for Linux.
+            max_rss / 1024
+        } else if cfg!(target_os = "macos") {
+            // ... and in bytes for BSD/macOS.
+            max_rss / 1024 / 1024
+        } else {
+            // don't risk confusing.
+            0
+        };
+        tracing::event!(
+            name: "max rss mib",
+            tracing::Level::INFO,
+            value = max_rss_mb,
+            counter = true
+        );
+    }
+    fn get_max_rss() -> Option<i64> {
+        use nix::sys::resource;
+
+        resource::getrusage(resource::UsageWho::RUSAGE_SELF)
+            .ok()
+            .map(|usage| usage.max_rss())
+    }
+}


### PR DESCRIPTION
Unlike the [original version](https://app.graphite.dev/github/pr/IrreducibleOSS/binius/590/%5Bcore%5D-track-maxrss), this uses nix which was handy.