### PR TITLE
Remove tracy support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,6 @@ perfetto-sys = { package = "tracing-profile-perfetto-sys", version = "0.10.1", p
 thiserror = "2.0.3"
 tracing = "0.1.37"
 tracing-subscriber = { version = "0.3.16", features = ["env-filter", "std"] }
-tracing-tracy = { version = "0.11.3", optional = true }
 
 [dev-dependencies]
 rayon = "1.10.0"
@@ -33,4 +32,3 @@ ittapi = ["dep:ittapi"]
 panic = []
 perf_counters = ["perf-event"]
 perfetto = ["dep:perfetto-sys"]
-tracy = ["dep:tracing-tracy"]

--- a/src/layers/init_tracing.rs
+++ b/src/layers/init_tracing.rs
@@ -42,7 +42,6 @@ pub enum Error {
 /// The following layers are added:
 /// - `PrintTreeLayer` (added always)
 /// - `IttApiLayer` (added if feature `ittapi` is enabled)
-/// - `TracyLayer` (added if feature `tracy` is enabled)
 /// - `PrintPerfCountersLayer` (added if feature `perf_counters` is enabled)
 ///
 /// Returns the guard that should be kept alive for the duration of the program.
@@ -69,17 +68,6 @@ pub fn init_tracing() -> Result<impl Drop, Error> {
         cfg_if! {
             if #[cfg(feature = "ittapi")] {
                 (layer.with(crate::IttApiLayer.with_env_filter()), guard)
-            } else {
-                (layer, guard)
-            }
-        }
-    };
-
-    // Add tracy layer if feature is enabled
-    let (layer, guard) = {
-        cfg_if! {
-            if #[cfg(feature = "tracy")] {
-                (layer.with(crate::TracyLayer::default().with_env_filter()), guard)
             } else {
                 (layer, guard)
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,6 @@
 //!     `PrintPerfCountersLayer`: prints aggregated performance counters for each span.
 //!     `PerfettoLayer`: uses a local or system-wide perfetto tracing service to record data.
 //!     `IttApiLayer`: logs data in Intel's [ITT API](https://www.intel.com/content/www/us/en/docs/vtune-profiler/user-guide/2023-1/instrumentation-and-tracing-technology-apis.html)
-//!     `TracyLayer`: re-exports the `tracing_tracy::TracyLayer`.
 //!
 //! `init_tracing` is a convenience function that initializes the tracing with the default values
 //! depending on the features enabled and environment variables set.
@@ -68,9 +67,6 @@ pub use {
 pub use layers::perfetto::{Layer as PerfettoLayer, PerfettoSettings as PerfettoCategorySettings};
 #[cfg(feature = "perfetto")]
 pub use perfetto_sys::PerfettoGuard;
-
-#[cfg(feature = "tracy")]
-pub use tracing_tracy::TracyLayer;
 
 pub use layers::init_tracing::init_tracing;
 


### PR DESCRIPTION
### TL;DR

Removed Tracy profiling integration from the tracing library.

### What changed?

- Removed the `tracing-tracy` dependency from `Cargo.toml`
- Removed the `tracy` feature flag
- Removed the `TracyLayer` initialization in `init_tracing.rs`
- Removed the re-export of `TracyLayer` from the library
- Updated documentation to remove references to Tracy

### How to test?

Verify that the codebase builds and runs correctly without the Tracy profiling integration. Ensure that other profiling methods (ITT API, Perfetto, perf counters) continue to work as expected.

### Why make this change?

Tracy has never been actually used, perfetto seems to to be superior to it. So we don't need to support it anymore