### PR TITLE
Fix clippy warnings for the latest toolchain

### DIFF
--- a/src/data/field_visitor.rs
+++ b/src/data/field_visitor.rs
@@ -35,7 +35,7 @@ impl tracing::field::Visit for StoringFieldVisitor<'_> {
     }
 
     fn record_debug(&mut self, field: &tracing::field::Field, value: &dyn std::fmt::Debug) {
-        self.0.insert(field.name(), format!("{:?}", value));
+        self.0.insert(field.name(), format!("{value:?}"));
     }
 }
 
@@ -126,8 +126,8 @@ impl Default for CounterValue {
 impl std::fmt::Display for CounterValue {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            CounterValue::Int(val) => write!(f, "{}", val),
-            CounterValue::Float(val) => write!(f, "{}", val),
+            CounterValue::Int(val) => write!(f, "{val}"),
+            CounterValue::Float(val) => write!(f, "{val}"),
         }
     }
 }

--- a/src/data/log_tree.rs
+++ b/src/data/log_tree.rs
@@ -12,7 +12,7 @@ impl std::fmt::Display for LogTree {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         writeln!(f, "{}", self.label)?;
         for event in &self.events {
-            writeln!(f, "├>{}", event)?;
+            writeln!(f, "├>{event}")?;
         }
         self.display_children(f, Vec::new())
     }
@@ -35,18 +35,18 @@ impl LogTree {
             let labels = child.label.split('\n');
             for (index, label) in labels.enumerate() {
                 match (index == 0, is_last) {
-                    (true, true) => writeln!(f, "{}└── {}", prefix, label)?,
-                    (true, false) => writeln!(f, "{}├── {}", prefix, label)?,
-                    (false, true) => writeln!(f, "{}    {}", prefix, label)?,
-                    (false, false) => writeln!(f, "{}│   {}", prefix, label)?,
+                    (true, true) => writeln!(f, "{prefix}└── {label}")?,
+                    (true, false) => writeln!(f, "{prefix}├── {label}")?,
+                    (false, true) => writeln!(f, "{prefix}    {label}")?,
+                    (false, false) => writeln!(f, "{prefix}│   {label}")?,
                 }
             }
 
             for event in &child.events {
                 if is_last {
-                    writeln!(f, "{}   ├>{}", prefix, event)?;
+                    writeln!(f, "{prefix}   ├>{event}")?;
                 } else {
-                    writeln!(f, "{}│  ├>{}", prefix, event)?;
+                    writeln!(f, "{prefix}│  ├>{event}")?;
                 }
             }
 

--- a/src/layers/graph.rs
+++ b/src/layers/graph.rs
@@ -344,7 +344,7 @@ impl GraphNode {
         }
 
         let tree = self.render_tree(self.execution_duration, config);
-        println!("{}", tree);
+        println!("{tree}");
     }
 
     fn label(&self, root_time: std::time::Duration, config: &Config) -> String {
@@ -400,7 +400,7 @@ impl GraphNode {
                     let mut indexed_child = child.clone();
                     indexed_child
                         .metadata
-                        .insert("index", format!("{}", name_count));
+                        .insert("index", format!("{name_count}"));
                     children.push(indexed_child);
                 } else {
                     aggregated_node = aggregated_node

--- a/src/layers/perfetto.rs
+++ b/src/layers/perfetto.rs
@@ -63,7 +63,7 @@ impl Visit for SpanVisitor<'_> {
     }
 
     fn record_debug(&mut self, field: &Field, debug: &dyn std::fmt::Debug) {
-        self.0.add_string_arg(field.name(), &format!("{:?}", debug));
+        self.0.add_string_arg(field.name(), &format!("{debug:?}"));
     }
 }
 

--- a/src/layers/print_perf_counters.rs
+++ b/src/layers/print_perf_counters.rs
@@ -88,7 +88,7 @@ impl SpanData {
 
     fn print_table(&self, field_names: &[String], out: &mut impl Write) -> std::io::Result<()> {
         for (name, value) in field_names.iter().zip(self.aggregate.0.iter()) {
-            writeln!(out, "    {}: {}", name, value)?;
+            writeln!(out, "    {name}: {value}")?;
         }
 
         Ok(())


### PR DESCRIPTION
Fix clippy warnings for the latest Rust toolchain