### PR TITLE
Bump package version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-version = "0.10.9"
+version = "0.10.10"
 edition = "2021"
 name = "tracing-profile"
 authors = ["Irreducible Team <opensource@irreducible.com>"]


### PR DESCRIPTION
### TL;DR

Bump version from 0.10.9 to 0.10.10

### What changed?

Updated the package version in Cargo.toml from 0.10.9 to 0.10.10.

### How to test?

Verify that the version number in Cargo.toml is correctly updated to 0.10.10.

### Why make this change?

This version bump is needed to prepare for a new release that includes recent changes to the codebase.