### PR TITLE
[WIP] feat: add common subnode aggregation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-version = "0.10.11"
+version = "0.10.12"
 edition = "2021"
 name = "tracing-profile"
 authors = ["Irreducible Team <opensource@irreducible.com>"]

--- a/examples/filtered.rs
+++ b/examples/filtered.rs
@@ -1,0 +1,80 @@
+use std::thread;
+use std::time::Duration;
+
+use tracing::{debug_span, event, instrument::WithSubscriber, level_filters::LevelFilter, Level};
+use tracing_profile::{PrintTreeConfig, PrintTreeLayer};
+use tracing_subscriber::prelude::*;
+use tracing_subscriber::EnvFilter;
+
+fn make_spans() {
+    event!(name: "event outside of span", Level::DEBUG, {value = 10});
+    event!(name: "test_instant_event", Level::DEBUG, test_key = "test_value");
+
+    {
+        let span = debug_span!("root span");
+        let _scope1 = span.enter();
+        thread::sleep(Duration::from_millis(20));
+
+        // child spans 1 and 2 are siblings
+        let span2 = debug_span!("child span1", field1 = "value1", perfetto_track_id = 5);
+        let scope2 = span2.enter();
+        thread::sleep(Duration::from_millis(20));
+        drop(scope2);
+
+        let span3 = debug_span!(
+            "child span2",
+            field2 = "value2",
+            value = 20,
+            perfetto_track_id = 5,
+            perfetto_flow_id = 10
+        );
+        let _scope3 = span3.enter();
+
+        thread::sleep(Duration::from_millis(20));
+        event!(name: "event in span2", Level::DEBUG, {value = 100});
+
+        // child spans 3 and 4 are siblings
+        let span = debug_span!("child span3", field3 = "value3");
+        let scope = span.enter();
+        thread::sleep(Duration::from_millis(20));
+        event!(name: "custom event", Level::DEBUG, {field5 = "value5", counter = true, value = 30});
+        drop(scope);
+
+        thread::spawn(|| {
+            let span = debug_span!("child span5", field5 = "value5");
+            let _scope = span.enter();
+            thread::sleep(Duration::from_millis(20));
+            event!(name: "custom event", Level::DEBUG, {field5 = "value6", counter = true, value = 10});
+        }).join().unwrap();
+
+        let span = debug_span!("child span4", field4 = "value4", perfetto_flow_id = 10);
+        thread::sleep(Duration::from_millis(20));
+        event!(name: "custom event", Level::DEBUG, {field5 = "value5", counter = true, value = 40});
+        let scope = span.enter();
+        thread::sleep(Duration::from_millis(20));
+        drop(scope);
+    }
+    event!(name: "event after last span", Level::DEBUG, {value = 20});
+}
+
+fn main() {
+    let (tree_layer, _guard) = PrintTreeLayer::new(PrintTreeConfig {
+        attention_above_percent: 25.0,
+        relevant_above_percent: 2.5,
+        hide_below_percent: 1.0,
+        display_unaccounted: false,
+        no_color: false,
+        accumulate_spans_count: false,
+        accumulate_events: false,
+    });
+    let perf_filter = EnvFilter::builder()
+        .with_default_directive("trace".parse().unwrap())
+        .with_env_var("RUST_PERF_LOG")
+        .from_env_lossy();
+
+    tracing_subscriber::registry()
+        .with(tree_layer.with_filter(perf_filter))
+        .init();
+
+    make_spans();
+}

--- a/examples/filtered_instrumented.rs
+++ b/examples/filtered_instrumented.rs
@@ -1,0 +1,88 @@
+use std::thread;
+use std::time::Duration;
+
+use tracing::{debug_span, event, instrument::WithSubscriber, level_filters::LevelFilter, Level};
+use tracing_profile::{PrintTreeConfig, PrintTreeLayer};
+use tracing_subscriber::prelude::*;
+use tracing_subscriber::EnvFilter;
+
+#[tracing::instrument]
+fn sleep_a_bit() {
+    thread::sleep(Duration::from_millis(10));
+}
+
+#[tracing::instrument]
+fn sleep_a_bit_and_yell() {
+    thread::sleep(Duration::from_millis(10));
+    event!(name: "yelling", Level::DEBUG, { value = 5 });
+}
+
+#[tracing::instrument]
+fn sleep_a_bit_with_args(foo: &str, bar: u32) {
+    thread::sleep(Duration::from_millis(10));
+    sleep_a_bit();
+}
+
+#[tracing::instrument(skip(foo, bar))]
+fn sleep_a_bit_with_skipped(foo: &str, bar: u32) {
+    thread::sleep(Duration::from_millis(10));
+    sleep_a_bit();
+}
+
+#[tracing::instrument]
+fn root_fn() {
+    sleep_a_bit();
+    sleep_a_bit();
+    sleep_a_bit();
+    sleep_a_bit_and_yell();
+    sleep_a_bit_with_args("hello", 42);
+    sleep_in_thread();
+
+    for u in 0..5 {
+        sleep_a_bit_with_args("in loop", u);
+    }
+    for u in 0..5 {
+        sleep_a_bit_with_skipped("in loop", u);
+    }
+}
+
+fn sleep_in_thread() {
+    thread::spawn(|| {
+        sleep_a_bit_with_args(&"Im in a thread", 22);
+    })
+    .join()
+    .unwrap();
+}
+
+fn make_spans() {
+    event!(name: "event outside of span", Level::DEBUG, {value = 10});
+    event!(name: "test_instant_event", Level::DEBUG, test_key = "test_value");
+
+    {
+        root_fn();
+    }
+    event!(name: "event after last span", Level::DEBUG, {value = 20});
+}
+
+fn main() {
+    let (tree_layer, _guard) = PrintTreeLayer::new(PrintTreeConfig {
+        attention_above_percent: 25.0,
+        relevant_above_percent: 2.5,
+        hide_below_percent: 1.0,
+        display_unaccounted: false,
+        no_color: true,
+        accumulate_spans_count: true,
+        accumulate_events: true,
+        aggregate_similar_siblings: true,
+    });
+    let perf_filter = EnvFilter::builder()
+        .with_default_directive("trace".parse().unwrap())
+        .with_env_var("RUST_PERF_LOG")
+        .from_env_lossy();
+
+    tracing_subscriber::registry()
+        .with(tree_layer.with_filter(perf_filter))
+        .init();
+
+    make_spans();
+}

--- a/examples/prefetto_base.rs
+++ b/examples/prefetto_base.rs
@@ -1,0 +1,63 @@
+use std::thread;
+use std::time::Duration;
+
+use tracing::{debug_span, event, Level};
+use tracing_profile::init_tracing;
+
+fn make_spans() {
+    event!(name: "event outside of span", Level::DEBUG, {value = 10});
+    event!(name: "test_instant_event", Level::DEBUG, test_key = "test_value");
+
+    {
+        let span = debug_span!("root span");
+        let _scope1 = span.enter();
+        thread::sleep(Duration::from_millis(20));
+
+        // child spans 1 and 2 are siblings
+        let span2 = debug_span!("child span1", field1 = "value1", perfetto_track_id = 5);
+        let scope2 = span2.enter();
+        thread::sleep(Duration::from_millis(20));
+        drop(scope2);
+
+        let span3 = debug_span!(
+            "child span2",
+            field2 = "value2",
+            value = 20,
+            perfetto_track_id = 5,
+            perfetto_flow_id = 10
+        );
+        let _scope3 = span3.enter();
+
+        thread::sleep(Duration::from_millis(20));
+        event!(name: "event in span2", Level::DEBUG, {value = 100});
+
+        // child spans 3 and 4 are siblings
+        let span = debug_span!("child span3", field3 = "value3");
+        let scope = span.enter();
+        thread::sleep(Duration::from_millis(20));
+        event!(name: "custom event", Level::DEBUG, {field5 = "value5", counter = true, value = 30});
+        drop(scope);
+
+        thread::spawn(|| {
+            let span = debug_span!("child span5", field5 = "value5");
+            let _scope = span.enter();
+            thread::sleep(Duration::from_millis(20));
+            event!(name: "custom event", Level::DEBUG, {field5 = "value6", counter = true, value = 10});
+        }).join().unwrap();
+
+        let span = debug_span!("child span4", field4 = "value4", perfetto_flow_id = 10);
+        thread::sleep(Duration::from_millis(20));
+        event!(name: "custom event", Level::DEBUG, {field5 = "value5", counter = true, value = 40});
+        let scope = span.enter();
+        thread::sleep(Duration::from_millis(20));
+        drop(scope);
+    }
+    event!(name: "event after last span", Level::DEBUG, {value = 20});
+}
+
+fn main() {
+    // let _test_dir = PerfettoTestDir::new();
+    let _guard = init_tracing().unwrap();
+
+    make_spans();
+}

--- a/src/layers/graph.rs
+++ b/src/layers/graph.rs
@@ -46,6 +46,12 @@ pub struct Config {
     /// Corresponds to the `TREE_LAYER_ACCUMULATE_SPANS_COUNT` environment variable.
     pub accumulate_spans_count: bool,
 
+    /// EXPERIMENTAL:
+    /// If enabled, similar sibling nodes will be aggregated together.
+    /// In essence spans that share name, fields and children will be merged together.
+    /// This means that the start+end time will be wrong but the durations are summed.
+    pub aggregate_similar_siblings: bool,
+
     /// Whether to disable color output.
     /// Corresponds to the `NO_COLOR` environment variable.
     pub no_color: bool,
@@ -60,6 +66,7 @@ impl Config {
             display_unaccounted: get_env_var("TREE_LAYER_DISPLAY_", false),
             accumulate_events: get_bool_env_var("TREE_LAYER_ACCUMULATE_EVENTS", true),
             accumulate_spans_count: get_bool_env_var("TREE_LAYER_ACCUMULATE_SPANS_COUNT", false),
+            aggregate_similar_siblings: get_bool_env_var("TREE_LAYER_ACCUMULATE_SIBLINGS", false),
             no_color: get_bool_env_var("NO_COLOR", false),
         }
     }
@@ -165,7 +172,7 @@ where
         &self,
         attrs: &span::Attributes<'_>,
         id: &span::Id,
-        _ctx: tracing_subscriber::layer::Context<'_, S>,
+        ctx: tracing_subscriber::layer::Context<'_, S>,
     ) {
         if !self.is_main_thread() {
             return;
@@ -181,6 +188,8 @@ where
         let Ok(mut state) = self.state.lock() else {
             return err_msg!("failed to get mutex");
         };
+        // RN I need this for debugging...
+        graph_node.name = ctx.span(id).map(|s| s.name()).unwrap_or("unknown span");
 
         state.unfinished_spans.insert(id.into_u64(), graph_node);
     }
@@ -243,6 +252,7 @@ where
             .started
             .map(|started| Instant::elapsed(&started))
             .unwrap_or_default();
+        // Q: why is the name assigned on finish and not on start?
         node.name = span.name();
 
         let parent = match span.parent() {
@@ -251,7 +261,10 @@ where
                     return err_msg!("failed to get parent node");
                 };
 
-                parent_node.child_nodes.push(node);
+                if self.config.aggregate_similar_siblings {
+                    node.summarize_children();
+                }
+                parent_node.push_node(node, self.config.aggregate_similar_siblings);
                 Some(p.id().clone())
             }
             None => {
@@ -308,6 +321,85 @@ struct GraphNode {
 }
 
 impl GraphNode {
+    fn is_equivalent(&self, other: &GraphNode) -> bool {
+        let base_same = self.name == other.name && self.metadata == other.metadata;
+        let children_same = self.child_nodes.len() == other.child_nodes.len()
+            && self
+                .child_nodes
+                .iter()
+                .zip(other.child_nodes.iter())
+                .all(|(a, b)| a.is_equivalent(b));
+        // Q: is all of 2 empty true?
+        // A: it is!
+        return base_same && children_same;
+    }
+
+    fn fold(&mut self, other: GraphNode) -> () {
+        // Replace start with the min start time if present
+        self.started = other
+            .started
+            .map(|s| self.started.map(|s0| s0.min(s)).unwrap_or(s))
+            .or(self.started);
+        self.execution_duration += other.execution_duration;
+        self.call_count += other.call_count;
+        self.events += &other.events;
+
+        // TODO reimplement as drain so I dont have to clone
+        for (i, left_node) in self.child_nodes.iter_mut().enumerate() {
+            if let Some(right_node) = other.child_nodes.get(i) {
+                if left_node.is_equivalent(right_node) {
+                    left_node.fold(right_node.clone());
+                } else {
+                    println!("This should not happen ... equivalence check should have failed.");
+                    left_node.child_nodes.push(right_node.clone());
+                }
+            }
+        }
+    }
+
+    fn summarize_children(&mut self) {
+        // In essence we check if any of out children are equivalent and if so we fold them
+        // together.
+        //
+        // we start with the first and just iterate over the rest.
+
+        let mut out = Vec::new();
+        let init_len = self.child_nodes.len();
+        while self.child_nodes.len() > 0 {
+            let mut node = self.child_nodes.pop().expect("should have node");
+            node.summarize_children();
+            let mut i = 0;
+            while i < self.child_nodes.len() {
+                if node.is_equivalent(&self.child_nodes[i]) {
+                    let other = self.child_nodes.remove(i);
+                    node.fold(other);
+                } else {
+                    i += 1;
+                }
+            }
+            out.push(node);
+            if out.len() > init_len {
+                // something is wrong, we should not be growing the number of nodes
+                break;
+            }
+        }
+        self.child_nodes = out;
+    }
+
+    fn push_node(&mut self, node: GraphNode, try_merge: bool) {
+        if try_merge {
+            for existing in self.child_nodes.iter_mut() {
+                if existing.is_equivalent(&node) {
+                    existing.fold(node);
+                    return;
+                }
+            }
+        }
+        self.child_nodes.push(node);
+    }
+}
+
+impl GraphNode {
     fn new(name: &'static str) -> Self {
         Self {
             name,
@@ -341,6 +433,9 @@ impl GraphNode {
     fn print(mut self, config: &Config) {
         if config.accumulate_events {
             self.accumulate_children_events(config.accumulate_spans_count);
+        }
+        if config.aggregate_similar_siblings {
+            self.summarize_children();
         }
 
         let tree = self.render_tree(self.execution_duration, config);
@@ -473,6 +568,13 @@ mod tests {
         std::{thread, time::Duration},
         tracing::{debug_span, event, Level},
     };
+
+    #[test]
+    fn test_summarize_nodes() {
+        // TODO:Add test for aggregation of nodes ...
+        use std::time::Duration;
+        let mut root = GraphNode::new("root");
+    }
 
     #[test]
     fn test_incremental_events_counts() {


### PR DESCRIPTION
[copying here the text from https://github.com/IrreducibleOSS/tracing-profile/issues/47]

Hello!

First of all thanks a lot for the crate, it has been incredibly handy.
I was wondering if you would be interested in a feature that I am experimenting with and found useful.

The main issue is that for calls that are executed in loops, I generally require knowing how much the aggregate time was instead of the per-call timing, so aggregating equivalent sub-graphs greatly simplifies this process.

Example (That I should have made more minimal ... but shows the point):

```rust
use std::thread;
use std::time::Duration;

use tracing::{debug_span, event, instrument::WithSubscriber, level_filters::LevelFilter, Level};
use tracing_profile::{PrintTreeConfig, PrintTreeLayer};
use tracing_subscriber::prelude::*;
use tracing_subscriber::EnvFilter;

#[tracing::instrument]
fn sleep_a_bit() {
    thread::sleep(Duration::from_millis(10));
}

#[tracing::instrument]
fn sleep_a_bit_and_yell() {
    thread::sleep(Duration::from_millis(10));
    event!(name: "yelling", Level::DEBUG, { value = 5 });
}

#[tracing::instrument]
fn sleep_a_bit_with_args(foo: &str, bar: u32) {
    thread::sleep(Duration::from_millis(10));
    sleep_a_bit();
}

#[tracing::instrument(skip(foo, bar))]
fn sleep_a_bit_with_skipped(foo: &str, bar: u32) {
    thread::sleep(Duration::from_millis(10));
    sleep_a_bit();
}

#[tracing::instrument]
fn all_the_sleeps() {
    sleep_a_bit();
    sleep_a_bit_and_yell();
    sleep_a_bit_with_args(&"hi", 42);
}

#[tracing::instrument]
fn root_fn() {
    for u in 0..5 {
        all_the_sleeps();
    }
}

fn make_spans() {
    event!(name: "event outside of span", Level::DEBUG, {value = 10});
    event!(name: "test_instant_event", Level::DEBUG, test_key = "test_value");

    {
        root_fn();
    }
    event!(name: "event after last span", Level::DEBUG, {value = 20});
}

fn main() {
    use std::env;

    let my_var = env::var("BUNDLE");
    let aggregate_similar_siblings = match my_var {
        Ok(val) if val == "1" || val.to_lowercase() == "true" => true,
        _ => false,
    };
    let (tree_layer, _guard) = PrintTreeLayer::new(PrintTreeConfig {
        attention_above_percent: 25.0,
        relevant_above_percent: 2.5,
        hide_below_percent: 1.0,
        display_unaccounted: false,
        no_color: true,
        accumulate_spans_count: false,
        accumulate_events: false,
        aggregate_similar_siblings, //// <------ This is the new guy
    });
    let perf_filter = EnvFilter::builder()
        .with_default_directive("trace".parse().unwrap())
        .with_env_var("RUST_PERF_LOG")
        .from_env_lossy();

    tracing_subscriber::registry()
        .with(tree_layer.with_filter(perf_filter))
        .init();

    make_spans();
}

```

Right now outputs the very verbose:

```
> event outside of span { value: 10 }: 1
> test_instant_event { test_key: test_value }: 1

root_fn [ 237.43ms | 100.00% ]
├── all_the_sleeps [ 48.13ms | 20.27% ] { index = 1 }
│  ├── sleep_a_bit [ 12.26ms | 5.16% ]
│  ├── sleep_a_bit_and_yell [ 12.57ms | 5.30% ]
│  │  ├>yelling { value: 5 }: 1
│  └── sleep_a_bit_with_args [ 23.20ms | 9.77% ] { foo = hi, bar = 42 }
│     └── sleep_a_bit [ 10.89ms | 4.59% ]
├── all_the_sleeps [ 49.33ms | 20.78% ] { index = 2 }
│  ├── sleep_a_bit [ 12.54ms | 5.28% ]
│  ├── sleep_a_bit_and_yell [ 12.59ms | 5.30% ]
│  │  ├>yelling { value: 5 }: 1
│  └── sleep_a_bit_with_args [ 24.08ms | 10.14% ] { foo = hi, bar = 42 }
│     └── sleep_a_bit [ 11.47ms | 4.83% ]
├── all_the_sleeps [ 47.18ms | 19.87% ] { index = 3 }
│  ├── sleep_a_bit [ 11.64ms | 4.90% ]
│  ├── sleep_a_bit_and_yell [ 11.07ms | 4.66% ]
│  │  ├>yelling { value: 5 }: 1
│  └── sleep_a_bit_with_args [ 24.33ms | 10.25% ] { foo = hi, bar = 42 }
│     └── sleep_a_bit [ 11.82ms | 4.98% ]
├── all_the_sleeps [ 45.87ms | 19.32% ] { index = 4 }
│  ├── sleep_a_bit [ 10.76ms | 4.53% ]
│  ├── sleep_a_bit_and_yell [ 10.98ms | 4.62% ]
│  │  ├>yelling { value: 5 }: 1
│  └── sleep_a_bit_with_args [ 23.98ms | 10.10% ] { foo = hi, bar = 42 }
│     └── sleep_a_bit [ 12.17ms | 5.13% ]
└── all_the_sleeps [ 46.60ms | 19.63% ]
   ├── sleep_a_bit [ 11.46ms | 4.83% ]
   ├── sleep_a_bit_and_yell [ 11.79ms | 4.97% ]
   │  ├>yelling { value: 5 }: 1
   └── sleep_a_bit_with_args [ 23.18ms | 9.76% ] { foo = hi, bar = 42 }
      └── sleep_a_bit [ 10.53ms | 4.43% ]

> event after last span { value: 20 }: 1

```

But if we aggregate all equivalent sub-graphs, we get the more concise:

```
> event outside of span { value: 10 }: 1
> test_instant_event { test_key: test_value }: 1

root_fn [ 231.50ms | 100.00% ]
└── all_the_sleeps [ 230.95ms | 99.76% ] (5 calls)
   ├── sleep_a_bit [ 59.48ms | 25.69% ] (5 calls)
   ├── sleep_a_bit_and_yell [ 60.02ms | 25.93% ] (5 calls)
   │  ├>yelling { value: 5 }: 5
   └── sleep_a_bit_with_args [ 110.86ms | 47.89% ] (5 calls)
      └── sleep_a_bit [ 54.41ms | 23.50% ] (5 calls)

> event after last span { value: 20 }: 1
```

LMK if you would be interested in the PR, I can polish my branch and make it a thing. (https://github.com/jspaezp/tracing-profile/tree/feat/aggregate_common right now ... there are a couple of TODOs I would like to handle before it "goes into the wild" but has worked well for a couple of my projects)

Best!

