### PR TITLE
chore: remove the Tracy layer

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,7 +40,6 @@ This is a Rust library implementing profiling layers for the `tracing` crate. Th
    - `PrintPerfCountersLayer`: Aggregates and prints performance counters (Linux only, requires `perf_counters` feature)
    - `PerfettoLayer`: Integrates with Perfetto tracing system (Linux, macOS, and Android, requires `perfetto` feature)
    - `IttApiLayer`: Intel VTune integration (requires `ittapi` feature)
-   - `TracyLayer`: Re-exported from `tracing-tracy` (requires `tracy` feature)
 
 2. **Data Structures** (`src/data/`): Core data management
    - Span metadata tracking and storage
@@ -63,7 +62,6 @@ This is a Rust library implementing profiling layers for the `tracing` crate. Th
 - `perf_counters`: Enables Linux performance counter support
 - `perfetto`: Enables Perfetto tracing integration
 - `ittapi`: Enables Intel VTune integration
-- `tracy`: Enables Tracy profiler integration
 - `panic`: Converts errors from eprintln! to panic!
 
 ### Testing Approach

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,6 @@ perfetto-sys = { package = "tracing-profile-perfetto-sys", version = "0.10.1", p
 thiserror = "2.0.3"
 tracing = "0.1.37"
 tracing-subscriber = { version = "0.3.16", features = ["env-filter", "std"] }
-tracing-tracy = { version = "0.11.3", optional = true }
 
 [target.'cfg(unix)'.dependencies]
 nix = { version = "0.29", features = ["time", "resource"] }
@@ -39,4 +38,3 @@ ittapi = ["dep:ittapi"]
 panic = []
 perf_counters = ["perf-event"]
 perfetto = ["dep:perfetto-sys", "gen_filename"]
-tracy = ["dep:tracing-tracy"]

--- a/src/layers/init_tracing.rs
+++ b/src/layers/init_tracing.rs
@@ -60,7 +60,6 @@ use filename_support::BuilderOption;
 /// - PrintTreeLayer (always enabled)
 /// - PerfettoLayer (if perfetto feature enabled)
 /// - IttApiLayer (if ittapi feature enabled)
-/// - TracyLayer (if tracy feature enabled)
 /// - PrintPerfCountersLayer (if perf_counters feature enabled)
 ///
 /// The builder parameter allows customization of perfetto trace filenames
@@ -95,17 +94,6 @@ fn init_tracing_internal(_builder: BuilderOption) -> Result<impl Drop, Error> {
         cfg_if! {
             if #[cfg(feature = "ittapi")] {
                 (layer.with(crate::IttApiLayer::new().with_env_filter()), guard)
-            } else {
-                (layer, guard)
-            }
-        }
-    };
-
-    // Add tracy layer if feature is enabled
-    let (layer, guard) = {
-        cfg_if! {
-            if #[cfg(feature = "tracy")] {
-                (layer.with(crate::TracyLayer::default().with_env_filter()), guard)
             } else {
                 (layer, guard)
             }
@@ -149,7 +137,6 @@ fn init_tracing_internal(_builder: BuilderOption) -> Result<impl Drop, Error> {
 /// The following layers are added:
 /// - `PrintTreeLayer` (added always)
 /// - `IttApiLayer` (added if feature `ittapi` is enabled)
-/// - `TracyLayer` (added if feature `tracy` is enabled)
 /// - `PrintPerfCountersLayer` (added if feature `perf_counters` is enabled)
 ///
 /// Returns the guard that should be kept alive for the duration of the program.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,6 @@
 //!     `PrintPerfCountersLayer`: prints aggregated performance counters for each span.
 //!     `PerfettoLayer`: uses a local or system-wide perfetto tracing service to record data.
 //!     `IttApiLayer`: logs data in Intel's [ITT API](https://www.intel.com/content/www/us/en/docs/vtune-profiler/user-guide/2023-1/instrumentation-and-tracing-technology-apis.html)
-//!     `TracyLayer`: re-exports the `tracing_tracy::TracyLayer`.
 //!
 //! `init_tracing` is a convenience function that initializes the tracing with the default values
 //! depending on the features enabled and environment variables set.
@@ -98,9 +97,6 @@ pub use {
 pub use layers::perfetto::{Layer as PerfettoLayer, PerfettoSettings as PerfettoCategorySettings};
 #[cfg(feature = "perfetto")]
 pub use perfetto_sys::PerfettoGuard;
-
-#[cfg(feature = "tracy")]
-pub use tracing_tracy::TracyLayer;
 
 #[cfg(feature = "gen_filename")]
 pub use filename_builder::{FilenameBuilderError, TraceFilenameBuilder};


### PR DESCRIPTION
The `TracyLayer` was only a re-export of `tracing_tracy::TracyLayer` and is unused. This removes:

- the `tracy` feature and the `tracing-tracy` dependency (`Cargo.toml`)
- the `pub use tracing_tracy::TracyLayer` re-export (`lib.rs`)
- the tracy layer wiring in `init_tracing`
- the doc / CLAUDE references

Second in the maintenance stack, on top of #49 (now merged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>