### PR TITLE
chore: bump git2, ittapi, and nix to latest majors

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,8 +13,8 @@ repository = "https://github.com/IrreducibleOSS/tracing-profile"
 cfg-if = "1.0.0"
 chrono = { version = "0.4.40", optional = true }
 gethostname = { version = "1.0.0", optional = true }
-git2 = { version = "0.20.1", default-features = false, optional = true }
-ittapi = { version = "0.4.0", optional = true }
+git2 = { version = "0.21", default-features = false, optional = true }
+ittapi = { version = "0.5.0", optional = true }
 linear-map = "1.2.0"
 perfetto-sys = { package = "tracing-profile-perfetto-sys", version = "0.10.1", path = "perfetto-sys", optional = true }
 thiserror = "2.0.3"
@@ -22,7 +22,7 @@ tracing = "0.1.37"
 tracing-subscriber = { version = "0.3.16", features = ["env-filter", "std"] }
 
 [target.'cfg(unix)'.dependencies]
-nix = { version = "0.29", features = ["time", "resource"] }
+nix = { version = "0.31", features = ["time", "resource"] }
 
 [target.'cfg(windows)'.dependencies]
 windows = { version = "0.62.2", features = ["Win32_System_ProcessStatus", "Win32_System_Threading"] }

--- a/src/filename_utils.rs
+++ b/src/filename_utils.rs
@@ -45,11 +45,11 @@ pub struct GitInfo {
 pub fn get_git_info() -> Option<GitInfo> {
     let repo = Repository::discover(".").ok()?;
     let head = repo.head().ok()?;
-    let branch = head.shorthand()?.to_string();
+    let branch = head.shorthand().ok()?.to_string();
     let commit = head.peel_to_commit().ok()?;
     let commit_short = commit.id().to_string()[..7].to_string();
-    let commit_message = commit.message().map(|m| m.trim().to_string());
-    let commit_author = commit.author().name().map(|s| s.to_string());
+    let commit_message = commit.message().ok().map(|m| m.trim().to_string());
+    let commit_author = commit.author().name().ok().map(|s| s.to_string());
 
     // Format the commit timestamp as ISO-8601
     let commit_time = {


### PR DESCRIPTION
Bump the three dependencies that were behind a major version:

- `git2` 0.20 → 0.21
- `ittapi` 0.4 → 0.5
- `nix` 0.29 → 0.31

git2 0.21 changed `Reference::shorthand`, `Commit::message`, and `Signature::name` to return `Result` (to surface UTF-8 errors); `get_git_info` uses `.ok()` to preserve its existing "None on any error" behavior (`src/filename_utils.rs`).

`nix` lives under `[target.'cfg(unix)'.dependencies]` (from the "Fix compilation on Windows" change now on `main`); the bump is applied there, leaving the Windows `windows` dependency untouched.

Last in the maintenance stack, on top of #53 (now merged). `cargo update` had nothing else to do within semver.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>